### PR TITLE
Add MarkDown support

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -40,7 +40,7 @@ private fun getEnv(): EnvSet = getEnvOrNull("INSPECTOR_CONFIG")
  * Iterate over files.
  */
 context(EnvContext)
-private fun fileWalk(): Sequence<File> = context.root.walkDir { it.extension == "rst" }
+private fun fileWalk(): Sequence<File> = context.root.walkDir { it.extension == "rst" || it.extension == "md" }
 
 /**
  * Convert the file walk to RliFile objects.


### PR DESCRIPTION
Some projects use [MyST](https://myst-parser.readthedocs.io/en/latest/) for Sphinx projects, which uses the MarkDown extension. I tested and built the JAR locally and confirmed it works.